### PR TITLE
Scratch 2.0 comments ➡ Scratch 3.0 comments

### DIFF
--- a/scratchr2.user.css
+++ b/scratchr2.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Scratchr2
 @namespace      github.com/mxmou
-@version        1.4.4
+@version        1.5.0
 @description    Makes the Scratchr2 site look more like Scratch 3.0
 @author         Maximouse (https://scratch.mit.edu/users/Maximouse)
 @homepageURL    https://github.com/mxmou/customize-scratch
@@ -676,3 +676,34 @@
         text-decoration: none
     a:hover
         color: active
+    
+@-moz-document url-prefix("https://scratch.mit.edu/studios/"), url-prefix("https://scratch.mit.edu/users/")
+    .content
+        position: relative;
+        border: 1px solid #d9d9d9;
+        border-radius: 0 5px 5px 5px;
+        padding: 1rem;
+        margin-left: 1.5rem;
+        background-color: white;
+        max-width: 30.25rem;
+        overflow: visible !important;
+    .content:after
+        display: block;
+        position: absolute;
+        top: 0;
+        left: -12px;
+        border-bottom: 10px solid white;
+        border-left: 12px solid white;
+        border-radius: 0 0 0 12px;
+        width: 0;
+        content: "";
+    .content:before
+        display: block;
+        position: absolute;
+        top: -1px;
+        left: -13px;
+        border-bottom: 12px solid #d9d9d9;
+        border-left: 13px solid #d9d9d9;
+        border-radius: 0 0 0 13px;
+        width: 0;
+        content: "";


### PR DESCRIPTION
This pull request changes the 2.0 comments to 3.0 comments:
![image](https://user-images.githubusercontent.com/60622217/80799854-3f3dc200-8ba8-11ea-893f-a2af2e87e328.png)
I also have changed the version to 1.5.0 (you can change it if you want).