### PR TITLE
Fix ugly 'comments loading' background

### DIFF
--- a/scratchr2.user.css
+++ b/scratchr2.user.css
@@ -619,7 +619,7 @@
     #comments .comment
         margin-left: 0
     #comments-loading
-        background-color: transparent !important
+        background-color: transparent
 
 @-moz-document regexp("https://scratch.mit.edu/studios/.*")
     /* Studios */

--- a/scratchr2.user.css
+++ b/scratchr2.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Scratchr2
 @namespace      github.com/mxmou
-@version        1.7.4
+@version        1.7.5
 @description    Makes the Scratchr2 site look more like Scratch 3.0
 @author         Maximouse (https://scratch.mit.edu/users/Maximouse)
 @homepageURL    https://github.com/mxmou/customize-scratch
@@ -618,6 +618,8 @@
         color: text
     #comments .comment
         margin-left: 0
+    #comments-loading
+        background-color: transparent !important
 
 @-moz-document regexp("https://scratch.mit.edu/studios/.*")
     /* Studios */


### PR DESCRIPTION
Pull request #4 fixes the ugly highlight background with comments. But there are still some other ugly things. Like the 'comments loading' message:
![image](https://user-images.githubusercontent.com/60622217/81700578-20251700-9469-11ea-999c-053ddb413d91.png)
This pull request should fix that.